### PR TITLE
Support kernels 5.3.0+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-EXTRA_CFLAGS += -Wall -Wno-unused-variable
+EXTRA_CFLAGS += -Wall -Wno-unused-variable -mfentry
 
 obj-m += gspca_kinect2.o
 gspca_kinect2-objs += kinect2.o


### PR DESCRIPTION
Add -mfentry CFLAG, which resolves
    ERROR: "mcount" [gspca-kinect2/gspca_main.ko] undefined!
on kernels 5.3.0 (occurred on Ubuntu 5.3.0-53-lowlatency).

Tested also on default Ubuntu bionic kernel 4.15.0 (which
wouldn't need the flag) and it still works, so it doesn't
seem to break on older kernels either.