### PR TITLE
Fix device_caps error -22 (EINVAL) on Linux 5.4+

### DIFF
--- a/gspca.c
+++ b/gspca.c
@@ -1439,6 +1439,8 @@ static const struct video_device gspca_template = {
 	.fops = &dev_fops,
 	.ioctl_ops = &dev_ioctl_ops,
 	.release = video_device_release_empty, /* We use v4l2_dev.release */
+	.device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING
+		| V4L2_CAP_READWRITE,
 };
 
 /*


### PR DESCRIPTION
torvalds/linux@3c13505 broke this driver, requiring the video device's
device_caps be set in advance.

Set the same device caps that are reported from `vidioc_querycap()`.

Fixes #7.