### PR TITLE
Fix VFL_TYPE_GRABBER -> _VIDEO for kernel 5.7+

### DIFF
--- a/gspca.c
+++ b/gspca.c
@@ -22,6 +22,7 @@
 #define GSPCA_VERSION	"2.14.0"
 
 #include <linux/init.h>
+#include <linux/version.h>
 #include <linux/fs.h>
 #include <linux/vmalloc.h>
 #include <linux/sched.h>
@@ -1561,7 +1562,11 @@ int gspca_dev_probe2(struct usb_interface *intf,
 
 	/* init video stuff */
 	ret = video_register_device(&gspca_dev->vdev,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
 				  VFL_TYPE_GRABBER,
+#else
+				  VFL_TYPE_VIDEO,
+#endif
 				  -1);
 	if (ret < 0) {
 		pr_err("video_register_device err %d\n", ret);


### PR DESCRIPTION
torvalds/linux@238e4a5b renamed that VFL_TYPE from GRABBER
to VIDEO. Use the new enum name if the kernel header version
is >= 5.7.0.

Doesn't really depend on, but also doesn't make a lot of sense
merging this without merging #6 and #8 first.

(See grandchild/gspca-kinect2@master for working version)