### PR TITLE
Update kinect2.c, changed struct name to resolve conflict

### DIFF
--- a/kinect2.c
+++ b/kinect2.c
@@ -52,7 +52,7 @@ static const u32 start_cmd = 0x01;
 static const u32 stop_cmd  = 0x00;
 
 /* request packet for kinect2 sensor */
-struct request {
+struct k2_request {
 	u32 magic;
 	u32 cmdseq;
 	u32 reply_len;
@@ -66,7 +66,7 @@ struct sd {
 	struct gspca_dev gspca_dev; /* !! must be the first item */
 
 	u32 cmdseq;              /* a sequence number for control commands */
-	struct request request;  /* a buffer for sending control commands */
+	struct k2_request k2_request;  /* a buffer for sending control commands */
 	u32 response[32];        /* a buffer for receiving response */
 	u8  synced;              /* a flag for sd_depth_pkt_scan() */
 
@@ -115,7 +115,7 @@ static int send_cmd(struct gspca_dev *gspca_dev, u32 cmd,
 {
 	struct sd *sd = (struct sd *) gspca_dev;
 	struct usb_device *udev = gspca_dev->dev;
-	struct request *req = &sd->request;
+	struct k2_request *req = &sd->k2_request;
 	int actual_len, result = 0;
 	int res, i;
 


### PR DESCRIPTION
Hello,
having the struct named "request" causes a conflict on my system ubuntu 22.04 with OpenCV 4, when I changed the variable name and all the dependencies pointing to this struct, it compiled correctly.
